### PR TITLE
Exportation CSV, simplification correctStringLength

### DIFF
--- a/src/app/components/constitution-page/section/export-section/export-section.component.ts
+++ b/src/app/components/constitution-page/section/export-section/export-section.component.ts
@@ -7,8 +7,8 @@ import { Constitution } from 'src/app/types/constitution';
 import { Song } from 'src/app/types/song';
 import { AUTHORISATION_LEVEL, User } from 'src/app/types/user';
 
-const BASIC_TXT_HEADER: string = " ID |        Titre       |       Auteur       |     Ajouté Par     |\n";
-const TXT_SEPARATOR: string = "==================================================================== \n"
+const BASIC_TXT_HEADER = ' ID |        Titre       |       Auteur       |     Ajouté Par     |\n';
+const TXT_SEPARATOR = '==================================================================== \n';
 
 @Component({
   selector: 'export-section',
@@ -20,16 +20,16 @@ export class ExportSectionComponent implements OnInit {
   @Input() users: User[];
 
   private currentUser: User;
-  public isUserLoading: boolean = true;
+  public isUserLoading = true;
 
-  public EXPORT_FORMAT: string[] = ["Liste des chansons", "Google Sheets"];
+  public EXPORT_FORMAT: string[] = ['Liste des chansons', 'Google Sheets', 'csv'];
   public selectedExportFormat: string;
 
   private setting = {
     element: {
       dynamicDownload: null as HTMLElement
     }
-  }
+  };
 
   ngOnInit() {
     this.auth.user$.subscribe(newUser => {
@@ -37,13 +37,13 @@ export class ExportSectionComponent implements OnInit {
       if (newUser) {
         this.isUserLoading = false;
         if (this.currentUser.isAuthorized[AUTHORISATION_LEVEL.DEV_LEVEL]) {
-          this.EXPORT_FORMAT.push("Objet JSON");
+          this.EXPORT_FORMAT.push('Objet JSON');
         }
       }
     });
   }
 
-  constructor(private auth: AuthService,) {
+  constructor(private auth: AuthService, ) {
     this.selectedExportFormat = this.EXPORT_FORMAT[0];
   }
 
@@ -55,28 +55,25 @@ export class ExportSectionComponent implements OnInit {
   convertSongArrayToString(songs: Song[]): string {
     let text = BASIC_TXT_HEADER + TXT_SEPARATOR;
     for (const song of songs) {
-      text += this.correctStringLength(song.id.toString(), 4) + "|" + this.correctStringLength(song.shortTitle, 20) + "|" + this.correctStringLength(song.author, 20) + "|" + this.correctStringLength(this.showDisplayName(song.patron), 20) + "|" + "\n";
+      text += this.correctStringLength(song.id.toString(), 4) + '|' + this.correctStringLength(song.shortTitle, 20) + '|' + this.correctStringLength(song.author, 20) + '|' + this.correctStringLength(this.showDisplayName(song.patron), 20) + '|' + '\n';
     }
     return text;
   }
 
   convertSongArrayToGoogleSheets(songs: Song[]): string {
-    let text = "";
+    let text = '';
     for (const song of songs) {
-      text += '=LIEN_HYPERTEXTE("' + song.url + '"; "' + song.shortTitle + '")' + "\n";
+      text += '=LIEN_HYPERTEXTE("' + song.url + '"; "' + song.shortTitle + '")' + '\n';
     }
     return text;
   }
 
+  convertSongArrayToCsv(_: Song[]): string {
+    return this.constitution.songs.map((s) => `${s.id};${s.author};${s.shortTitle};${s.patron};${s.url}`).join('\n');
+  }
+
   correctStringLength(string: string, length: number): string {
-    if (string.length < length) {
-      while (string.length !== length) {
-        string += " ";
-      }
-    } else if (string.length > length) {
-      string = string.slice(0, length);
-    }
-    return string;
+    return string.slice(0, length).padEnd(length);
   }
 
   returnConstitutionData() {
@@ -86,24 +83,30 @@ export class ExportSectionComponent implements OnInit {
   dynamicDownloadTxt(format: string) {
     this.returnConstitutionData().subscribe((songs) => {
       switch (format) {
-        case "Liste des chansons":
+        case 'Liste des chansons':
           this.dyanmicDownloadByHtmlTag({
             fileName: this.constitution.name,
             text: this.convertSongArrayToString(songs)
           });
           break;
-        case "Objet JSON":
+        case 'Objet JSON':
           this.dyanmicDownloadByHtmlTag({
-            fileName: this.constitution.name + ".json",
+            fileName: this.constitution.name + '.json',
             text: JSON.stringify(songs, null, 2)
           });
           break;
-        case "Google Sheets":
+        case 'Google Sheets':
           this.dyanmicDownloadByHtmlTag({
             fileName: this.constitution.name,
             text: this.convertSongArrayToGoogleSheets(songs)
           });
           break;
+          case 'csv':
+            this.dyanmicDownloadByHtmlTag({
+              fileName: this.constitution.name + '.csv',
+              text: this.convertSongArrayToCsv(songs)
+            });
+            break;
         default:
           this.dyanmicDownloadByHtmlTag({
           fileName: this.constitution.name,
@@ -123,14 +126,14 @@ export class ExportSectionComponent implements OnInit {
     element.setAttribute('href', `data:${fileType};charset=utf-8,${encodeURIComponent(arg.text)}`);
     element.setAttribute('download', arg.fileName);
 
-    var event = new MouseEvent("click");
+    const event = new MouseEvent('click');
     element.dispatchEvent(event);
   }
 
   showDisplayName(uid: string): string {
     const user = this.users.find(x => x.uid === uid);
     if (user !== undefined) { return user.displayName; }
-    return "";
+    return '';
   }
 
 }

--- a/src/app/components/constitution-page/section/export-section/export-section.component.ts
+++ b/src/app/components/constitution-page/section/export-section/export-section.component.ts
@@ -22,7 +22,7 @@ export class ExportSectionComponent implements OnInit {
   private currentUser: User;
   public isUserLoading = true;
 
-  public EXPORT_FORMAT: string[] = ['Liste des chansons', 'Google Sheets', 'csv'];
+  public EXPORT_FORMAT: string[] = ['Liste des chansons', 'Google Sheets'];
   public selectedExportFormat: string;
 
   private setting = {

--- a/src/app/components/constitution-page/section/export-section/export-section.component.ts
+++ b/src/app/components/constitution-page/section/export-section/export-section.component.ts
@@ -37,7 +37,7 @@ export class ExportSectionComponent implements OnInit {
       if (newUser) {
         this.isUserLoading = false;
         if (this.currentUser.isAuthorized[AUTHORISATION_LEVEL.DEV_LEVEL]) {
-          this.EXPORT_FORMAT.push('Objet JSON');
+          this.EXPORT_FORMAT.push('Objet JSON', 'csv');
         }
       }
     });


### PR DESCRIPTION
1. Correction de lint automatique (mon installation de TSLint l'a fait a mon insu, normalement j'aurais fait ca dans un autre commit)
2. Permet d'exporter en CSV
3. Simplifié correctStringLength() en 2 appel de fonction String.prototype